### PR TITLE
Set org-hide colour for org-indent-mode

### DIFF
--- a/almost-mono-themes.el
+++ b/almost-mono-themes.el
@@ -182,6 +182,7 @@
       (org-todo (:bold t :foreground ,highlight))
       (org-done (:bold t :foreground ,success))
       (org-headline-done (:bold t :foreground ,foreground))
+      (org-hide (:foreground ,background))
 
       ;; various completion matches
       (vertico-current (:bold t :foreground ,foreground :background ,highlight))


### PR DESCRIPTION
Org-indent-mode hides leading asterisks for headlines, which relies on the org-hide foreground colour being set to whatever the theme background colour is.